### PR TITLE
Add capability to load static schemas for catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ config.sample.json:
   "start_datetime": "2017-01-01T00:00:00Z", // This can be set at the command line argument
   "end_datetime": "2017-02-01T00:00:00Z", // end_datetime is optional
   "limit": 100,
-  "start_always_inclusive": false // default is false, optional
+  "start_always_inclusive": false, // default is false, optional
+  "schema_path": "/absolute/path/to/schemas/directory" // default None, will attempt to infer schema
 }
 ```
 

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -119,7 +119,7 @@ def infer_schema(config, stream):
 
 def do_discover(config, stream, output_schema_file=None,
                 add_timestamp=True):
-    schema_file_path = os.path.join(config.get("schema_path", ""), stream["table"])
+    schema_file_path = os.path.join(config.get("schema_path", ""), f"{stream['table']}.json")
     if not config.get("schema_path"):
         LOGGER.info("No schema folder specified, attempting to infer schema")
         schema = infer_schema(config, stream)

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -119,7 +119,7 @@ def infer_schema(config, stream):
 
 def do_discover(config, stream, output_schema_file=None,
                 add_timestamp=True):
-    schema_file_path = os.path.join(config.get("schema_path"), stream["table"])
+    schema_file_path = os.path.join(config.get("schema_path", ""), stream["table"])
     if not config.get("schemas_path"):
         LOGGER.info("No schema folder specified, attempting to infer schema")
         schema = infer_schema(config, stream)

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -120,7 +120,7 @@ def infer_schema(config, stream):
 def do_discover(config, stream, output_schema_file=None,
                 add_timestamp=True):
     schema_file_path = os.path.join(config.get("schema_path", ""), stream["table"])
-    if not config.get("schemas_path"):
+    if not config.get("schema_path"):
         LOGGER.info("No schema folder specified, attempting to infer schema")
         schema = infer_schema(config, stream)
     elif not os.path.exists(schema_file_path):


### PR DESCRIPTION
Forked the repo and added this patch because schema inference seems have several bugs. The first is that it sees a string containing a numeric value as `type: integer`, which causes ingestion issues. The second is that schema inference tends to miss sparsely populated records, and sets their type to null.

This patch allows the user to specify a directory containing jsonschema files. When the file matches a given table name, then that static schema will be used instead.